### PR TITLE
It is better to use `React.createElemt(‘foo’)` instead of React.DOM.foo

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -5,12 +5,10 @@ var Arrow = require('./');
 var React = require('react');
 var ReactDOM = require('react-dom');
 
-var div = React.DOM.div;
-
 function App() {
   return (
-    div({style: {display: 'flex', alignItems: 'center', justifyContent: 'center'}},
-      div({style: {background: 'lightgray', display: 'flex'}},
+    React.createElement('div', {style: {display: 'flex', alignItems: 'center', justifyContent: 'center'}},
+      React.createElement('div', {style: {background: 'lightgray', display: 'flex'}},
         React.createElement(Arrow, {
           color: 'blue',
           borderWidth: 50,

--- a/index.js
+++ b/index.js
@@ -3,10 +3,6 @@
 var React = require('react');
 var PropTypes = require('prop-types');
 
-
-var svg = React.DOM.svg;
-var path = React.DOM.path;
-
 var ROOT_2 = Math.sqrt(2);
 
 function Arrow(props) {
@@ -37,14 +33,14 @@ function Arrow(props) {
   ];
 
   return (
-    svg({
+    React.createElement('svg', {
       xmlns: 'http://www.w3.org/svg/2000',
       width: landscape ? secondary : primary,
       height: landscape ? primary : secondary,
       style: props.style,
       className: props.className
     },
-      path({
+      React.createElement('path', {
         d: pathData.join(' '),
         fill: props.color,
         stroke: props.borderColor,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-svg-arrow",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A React component for tooltip and popover arrows",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "main": "index.js",
@@ -15,7 +15,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "0.14.x - 15.x"
+    "react": "0.14.x - 16.x"
   },
   "devDependencies": {
     "budo": "^8.2.1",


### PR DESCRIPTION
React.DOM.* is deprecated in React 16, this change will allow to use this component with react 16.x.